### PR TITLE
Modify HotIf to only target Railroader.exe

### DIFF
--- a/RailroaderScripts.ahk
+++ b/RailroaderScripts.ahk
@@ -1,7 +1,7 @@
 ﻿#Requires AutoHotkey v2.0
 
 ; Set of scripts to use for the game Railroader
-#HotIf WinActive("Railroader")
+#HotIf WinActive("ahk_exe Railroader.exe")
 
 ; Use Mouse 4 to toggle RMB for freelook
 XButton1:: 


### PR DESCRIPTION
This prevents the hotkeys from being active when viewing a folder named Railroader, like the game folder for example.